### PR TITLE
Fix 1.11 compat

### DIFF
--- a/src/input/io.jl
+++ b/src/input/io.jl
@@ -13,7 +13,7 @@ function read_milp(
         contents = GZip.open(path, "r") do f
             read(f, String)
         end
-        mps_path = tempname(; suffix = ".mps")
+        mps_path = string(tempname(), ".mps")
         open(mps_path, "w") do f
             write(f, contents)
         end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -16,5 +16,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8.14"
-JET = "0.11.0"
 Test = "1"


### PR DESCRIPTION
Supersedes #3 by avoiding the formatting noise and fixing the compat issues:

- use of `suffix`
- JET compat bound in tests