### PR TITLE
[PDLP] Check termination before restart

### DIFF
--- a/src/algorithms/pdlp.jl
+++ b/src/algorithms/pdlp.jl
@@ -79,10 +79,10 @@ function solve!(
                 step!(state, milp)
                 next!(prog; showvalues = prog_showvalues(state))
             end
-            if restart_check!(state, milp, algo)
-                restart!(state, algo)
-            elseif termination_check!(state, milp, algo)
+            if termination_check!(state, milp, algo)
                 break
+            elseif restart_check!(state, milp, algo)
+                restart!(state, algo)
             end
         end
         if termination_check!(state, milp, algo)

--- a/test/algorithms/all.jl
+++ b/test/algorithms/all.jl
@@ -53,7 +53,7 @@ end
 
 @testset "PDLP" begin
     @testset for (M, backend) in configs
-        algo = PDLP(Float64, Int, M; backend, termination_reltol = 1.0e-4, max_kkt_passes = 10^7, show_progress = false)
+        algo = PDLP(Float64, Int, M; backend, termination_reltol = 1.0e-5, max_kkt_passes = 10^7, show_progress = false)
         dataset = Netlib
         @testset for name in small_names
             test_optimizer(dataset, name, algo; cons_tol = 1.0e-2)

--- a/test/components/preconditioning.jl
+++ b/test/components/preconditioning.jl
@@ -1,6 +1,7 @@
 using CoolPDLP
 using LinearAlgebra
 using SparseArrays
+using Random: Xoshiro
 using Test
 
 @testset "Composition" begin
@@ -24,7 +25,8 @@ end
 end
 
 @testset "Preconditioner types" begin
-    A = sprand(10, 20, 0.4)
+    rng = Xoshiro(42)
+    A = sprand(rng, 10, 20, 0.4)
     cons = CoolPDLP.ConstraintMatrix(A, sparse(transpose(A)))
     @testset "Identity" begin
         id_prec = CoolPDLP.identity_preconditioner(cons)

--- a/test/components/termination.jl
+++ b/test/components/termination.jl
@@ -1,0 +1,10 @@
+@testset "Termination check not skipped" begin
+    c = [1.0, 1.0];
+    lc, A, uc = [1.0], sparse([1.0 1.0]), [Inf];
+    lv, uv = [0.0, 0.0], [Inf, Inf];
+
+    milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc);
+    algo = CoolPDLP.PDLP();
+    sol, stats = CoolPDLP.solve(milp, algo);
+    @test stats.termination_status == CoolPDLP.OPTIMAL
+end

--- a/test/components/termination.jl
+++ b/test/components/termination.jl
@@ -1,10 +1,10 @@
 @testset "Termination check not skipped" begin
-    c = [1.0, 1.0];
-    lc, A, uc = [1.0], sparse([1.0 1.0]), [Inf];
-    lv, uv = [0.0, 0.0], [Inf, Inf];
+    c = [1.0, 1.0]
+    lc, A, uc = [1.0], sparse([1.0 1.0]), [Inf]
+    lv, uv = [0.0, 0.0], [Inf, Inf]
 
-    milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc);
-    algo = CoolPDLP.PDLP();
-    sol, stats = CoolPDLP.solve(milp, algo);
+    milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc)
+    algo = CoolPDLP.PDLP()
+    sol, stats = CoolPDLP.solve(milp, algo)
     @test stats.termination_status == CoolPDLP.OPTIMAL
 end


### PR DESCRIPTION
Before this change, the MWE below runs forever since it restarts every time, so it never checks the termination criteria.
```julia
using CoolPDLP, SparseArrays

c = [1.0, 1.0];
lc, A, uc = [1.0], sparse([1.0 1.0]), [Inf];
lv, uv = [0.0, 0.0], [Inf, Inf];

milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc);
algo = CoolPDLP.PDLP();
sol, stats = CoolPDLP.solve(milp, algo);
sol.x, stats.termination_status
```