### PR TITLE
Initial non-incremental MOI interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,12 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
+[weakdeps]
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+
+[extensions]
+CoolPDLPMOIExt = "MathOptInterface"
+
 [compat]
 Adapt = "4.4.0"
 Atomix = "1.1.2"
@@ -29,6 +35,7 @@ DocStringExtensions = "0.9.5"
 IterativeSolvers = "0.9.4"
 KernelAbstractions = "0.9.38"
 LinearAlgebra = "1"
+MathOptInterface = "1"
 Printf = "1.11.0"
 ProgressMeter = "1.11.0"
 QPSReader = "0.2.1"

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -48,8 +48,7 @@ function MOI.is_empty(model::Optimizer)
             model.primal_status == MOI.UNKNOWN_RESULT_STATUS &&
             model.dual_status == MOI.UNKNOWN_RESULT_STATUS &&
             iszero(model.solve_time) &&
-            isnothing(model.sets) &&
-            isempty(model.options)
+            isnothing(model.sets)
     )
 end
 function MOI.empty!(model::Optimizer{T}) where {T}
@@ -62,7 +61,6 @@ function MOI.empty!(model::Optimizer{T}) where {T}
     model.dual_status = MOI.UNKNOWN_RESULT_STATUS
     model.solve_time = zero(T)
     model.sets = nothing
-    empty!(model.options)
     return
 end
 
@@ -209,11 +207,11 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
 
     sol, stats = CoolPDLP.solve(milp, algo)
 
-    dest.x = sol.x
-    dest.y = sol.y
-    dest.z = CoolPDLP.proj_multiplier.(c .- milp.At * sol.y, lv, uv)
+    dest.x = Array(sol.x)
+    dest.y = Array(sol.y)
+    dest.z = CoolPDLP.proj_multiplier.(c .- milp.At * dest.y, lv, uv)
 
-    raw_obj = CoolPDLP.objective_value(sol.x, milp)
+    raw_obj = CoolPDLP.objective_value(dest.x, milp)
     dest.obj_value = (max_sense ? -raw_obj : raw_obj) + obj_constant
     dest.solve_time = stats.time_elapsed
 

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -96,7 +96,7 @@ MOI.set(model::Optimizer, attr::MOI.RawOptimizerAttribute, value) = (model.optio
 MOI.get(::Optimizer, ::MOI.SolverName) = "CoolPDLP"
 MOI.get(::Optimizer, ::MOI.SolverVersion) = string(pkgversion(CoolPDLP))
 MOI.get(model::Optimizer, ::MOI.TerminationStatus) = model.termination_status
-MOI.get(model::Optimizer, ::MOI.ResultCount) = model.termination_status == MOI.OPTIMAL ? 1 : 0
+MOI.get(model::Optimizer, ::MOI.ResultCount) = model.termination_status != MOI.OPTIMIZE_NOT_CALLED ? 1 : 0
 MOI.get(model::Optimizer, ::MOI.RawStatusString) = string(model.termination_status)
 MOI.get(model::Optimizer, ::MOI.SolveTimeSec) = model.solve_time
 

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -85,7 +85,7 @@ function MOI.set(model::Optimizer{T}, ::MOI.TimeLimitSec, value) where {T}
     return if isnothing(value)
         delete!(model.options, :time_limit)
     else
-        model.options[:time_limit] = T(value)
+        model.options[:time_limit] = Float64(value)
     end
 end
 MOI.get(model::Optimizer, ::MOI.Silent) = model.silent

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -194,11 +194,18 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
     uc = cache.constraints.constants.upper
 
     milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc)
+
+    algorithm = pop!(dest.options, :algorithm, CoolPDLP.PDLP)
+
+    float_type = pop!(dest.options, :float_type, T)
+    int_type = pop!(dest.options, :int_type, Int)  # FIXME: get int type from float type?
+    matrix_type = pop!(dest.options, :matrix_type, SparseMatrixCSC)
+
     algo_opts = Dict{Symbol, Any}(:show_progress => !dest.silent)
     for (k, v) in dest.options
         algo_opts[k] = v
     end
-    algo = CoolPDLP.PDLP(; algo_opts...)
+    algo = algorithm(float_type, int_type, matrix_type; algo_opts...)
 
     sol, stats = CoolPDLP.solve(milp, algo)
 

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -222,9 +222,9 @@ function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
     raw_obj = CoolPDLP.objective_value(dest.x, milp)
     raw_dual_obj = (  # lᵀ|y|⁺ - uᵀ|y|⁻ + lᵥᵀ|z|⁺ - uᵥᵀ|z|⁻
         sum(CoolPDLP.safeprod_left.(lc, CoolPDLP.positive_part.(dest.y)))
-        - sum(CoolPDLP.safeprod_left.(uc, CoolPDLP.negative_part.(dest.y)))
-        + sum(CoolPDLP.safeprod_left.(lv, CoolPDLP.positive_part.(dest.z)))
-        - sum(CoolPDLP.safeprod_left.(uv, CoolPDLP.negative_part.(dest.z)))
+            - sum(CoolPDLP.safeprod_left.(uc, CoolPDLP.negative_part.(dest.y)))
+            + sum(CoolPDLP.safeprod_left.(lv, CoolPDLP.positive_part.(dest.z)))
+            - sum(CoolPDLP.safeprod_left.(uv, CoolPDLP.negative_part.(dest.z)))
     )
     dest.obj_value = (max_sense ? -raw_obj : raw_obj) + obj_constant
     dest.dual_obj_value = (max_sense ? -raw_dual_obj : raw_dual_obj) + obj_constant

--- a/ext/CoolPDLPMOIExt.jl
+++ b/ext/CoolPDLPMOIExt.jl
@@ -1,0 +1,229 @@
+module CoolPDLPMOIExt
+
+import MathOptInterface as MOI
+import CoolPDLP
+import SparseArrays: SparseMatrixCSC
+
+function __init__()
+    Base.setglobal!(CoolPDLP, :Optimizer, Optimizer)
+end
+
+MOI.Utilities.@product_of_sets(
+    RHS,
+    MOI.EqualTo{T},
+    MOI.GreaterThan{T},
+    MOI.LessThan{T},
+    MOI.Interval{T},
+)
+
+mutable struct Optimizer{T} <: MOI.AbstractOptimizer
+    x::Vector{T}
+    y::Vector{T}
+    z::Vector{T}
+    obj_value::T
+    termination_status::MOI.TerminationStatusCode
+    primal_status::MOI.ResultStatusCode
+    dual_status::MOI.ResultStatusCode
+    solve_time::T
+    silent::Bool
+    sets::Union{Nothing,RHS{T}}
+    options::Dict{Symbol,Any}
+
+    function Optimizer(; T = Float64)
+        return new{T}(
+            T[], T[], T[], zero(T),
+            MOI.OPTIMIZE_NOT_CALLED, MOI.UNKNOWN_RESULT_STATUS, MOI.UNKNOWN_RESULT_STATUS,
+            zero(T), false, nothing, Dict{Symbol,Any}(),
+        )
+    end
+end
+
+function MOI.is_empty(model::Optimizer)
+    return (
+        isempty(model.x) &&
+        isempty(model.y) &&
+        isempty(model.z) &&
+        iszero(model.obj_value) &&
+        model.termination_status == MOI.OPTIMIZE_NOT_CALLED &&
+        model.primal_status == MOI.UNKNOWN_RESULT_STATUS &&
+        model.dual_status == MOI.UNKNOWN_RESULT_STATUS &&
+        iszero(model.solve_time) &&
+        isnothing(model.sets) &&
+        isempty(model.options)
+    )
+end
+function MOI.empty!(model::Optimizer{T}) where {T}
+    empty!(model.x)
+    empty!(model.y)
+    empty!(model.z)
+    model.obj_value = zero(T)
+    model.termination_status = MOI.OPTIMIZE_NOT_CALLED
+    model.primal_status = MOI.UNKNOWN_RESULT_STATUS
+    model.dual_status = MOI.UNKNOWN_RESULT_STATUS
+    model.solve_time = zero(T)
+    model.sets = nothing
+    empty!(model.options)
+    return
+end
+
+const SUPPORTED_SET_TYPE{T} = Union{MOI.EqualTo{T}, MOI.GreaterThan{T}, MOI.LessThan{T}, MOI.Interval{T}}
+
+MOI.supports_constraint(::Optimizer{T}, ::Type{MOI.VariableIndex}, ::Type{<:SUPPORTED_SET_TYPE{T}}) where {T} = true
+MOI.supports_constraint(::Optimizer{T}, ::Type{MOI.ScalarAffineFunction{T}}, ::Type{<:SUPPORTED_SET_TYPE{T}}) where {T} = true
+MOI.supports(::Optimizer{T}, ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}) where {T} = true
+
+MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true
+MOI.supports(::Optimizer, ::MOI.Silent) = true
+MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
+MOI.supports(::Optimizer, ::MOI.RawOptimizerAttribute) = true
+
+MOI.get(model::Optimizer, ::MOI.TimeLimitSec) = get(model.options, :time_limit, nothing)
+function MOI.set(model::Optimizer{T}, ::MOI.TimeLimitSec, value) where {T}
+    if isnothing(value)
+        delete!(model.options, :time_limit)
+    else
+        model.options[:time_limit] = T(value)
+    end
+end
+MOI.get(model::Optimizer, ::MOI.Silent) = model.silent
+MOI.set(model::Optimizer, ::MOI.Silent, value::Bool) = (model.silent = value;)
+MOI.get(model::Optimizer, attr::MOI.RawOptimizerAttribute) = model.options[Symbol(attr.name)]
+MOI.set(model::Optimizer, attr::MOI.RawOptimizerAttribute, value) = (model.options[Symbol(attr.name)] = value;)
+
+MOI.get(::Optimizer, ::MOI.SolverName) = "CoolPDLP"
+MOI.get(::Optimizer, ::MOI.SolverVersion) = string(pkgversion(CoolPDLP))
+MOI.get(model::Optimizer, ::MOI.TerminationStatus) = model.termination_status
+MOI.get(model::Optimizer, ::MOI.ResultCount) = model.termination_status == MOI.OPTIMAL ? 1 : 0
+MOI.get(model::Optimizer, ::MOI.RawStatusString) = string(model.termination_status)
+MOI.get(model::Optimizer, ::MOI.SolveTimeSec) = model.solve_time
+
+function _status_check_index(model, attr, ret)
+    if attr.result_index > MOI.get(model, MOI.ResultCount())
+        return MOI.NO_SOLUTION
+    end
+    return ret
+end
+function _attr_check_index(model, attr, ret)
+    MOI.check_result_index_bounds(model, attr)
+    return ret
+end
+
+MOI.get(model::Optimizer, attr::MOI.PrimalStatus) = _status_check_index(model, attr, model.primal_status)
+MOI.get(model::Optimizer, attr::MOI.DualStatus) = _status_check_index(model, attr, model.dual_status)
+MOI.get(model::Optimizer, attr::MOI.ObjectiveValue) = _attr_check_index(model, attr, model.obj_value)
+
+function MOI.get(model::Optimizer, attr::MOI.VariablePrimal, vi::MOI.VariableIndex)
+    MOI.check_result_index_bounds(model, attr)
+    return model.x[vi.value]
+end
+
+function MOI.get(
+    model::Optimizer{T},
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},S},
+) where {T,S<:SUPPORTED_SET_TYPE{T}}
+    MOI.check_result_index_bounds(model, attr)
+    row = only(MOI.Utilities.rows(model.sets, ci))
+    return model.y[row]
+end
+
+function MOI.get(
+    model::Optimizer{T},
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}},
+) where {T}
+    MOI.check_result_index_bounds(model, attr)
+    return max(model.z[ci.value], zero(T))
+end
+
+function MOI.get(
+    model::Optimizer{T},
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{T}},
+) where {T}
+    MOI.check_result_index_bounds(model, attr)
+    return min(model.z[ci.value], zero(T))
+end
+
+function MOI.get(
+    model::Optimizer{T},
+    attr::MOI.ConstraintDual,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,S},
+) where {T,S<:Union{MOI.EqualTo{T},MOI.Interval{T}}}
+    MOI.check_result_index_bounds(model, attr)
+    return model.z[ci.value]
+end
+
+const OptimizerCache{T} = MOI.Utilities.GenericModel{T,
+    MOI.Utilities.ObjectiveContainer{T},
+    MOI.Utilities.VariablesContainer{T},
+    MOI.Utilities.MatrixOfConstraints{T,
+        MOI.Utilities.MutableSparseMatrixCSC{T,Int,MOI.Utilities.OneBasedIndexing},
+        MOI.Utilities.Hyperrectangle{T}, RHS{T},
+    },
+}
+
+function MOI.optimize!(dest::Optimizer{T}, src::MOI.ModelLike) where {T}
+    MOI.empty!(dest)
+    cache = OptimizerCache{T}()
+    index_map = MOI.copy_to(cache, src)
+
+    n = cache.constraints.coefficients.n
+    max_sense = cache.objective.sense == MOI.MAX_SENSE
+
+    A = convert(SparseMatrixCSC{T,Int}, cache.constraints.coefficients)
+
+    c = zeros(T, n)
+    obj_constant = zero(T)
+    if cache.objective.scalar_affine !== nothing
+        for term in cache.objective.scalar_affine.terms
+            c[term.variable.value] += term.coefficient
+        end
+        obj_constant = cache.objective.scalar_affine.constant
+    end
+    if max_sense
+        c .*= -one(T)
+    end
+
+    dest.sets = cache.constraints.sets
+    lv = cache.variables.lower
+    uv = cache.variables.upper
+    lc = cache.constraints.constants.lower
+    uc = cache.constraints.constants.upper
+
+    milp = CoolPDLP.MILP(; c, lv, uv, A, lc, uc)
+    algo_opts = Dict{Symbol,Any}(:show_progress => !dest.silent)
+    for (k, v) in dest.options
+        algo_opts[k] = v
+    end
+    algo = CoolPDLP.PDLP(; algo_opts...)
+    
+    sol, stats = CoolPDLP.solve(milp, algo)
+
+    dest.x = sol.x
+    dest.y = sol.y
+    dest.z = CoolPDLP.proj_multiplier.(c .- milp.At * sol.y, lv, uv)
+    
+    raw_obj = CoolPDLP.objective_value(sol.x, milp)
+    dest.obj_value = (max_sense ? -raw_obj : raw_obj) + obj_constant
+    dest.solve_time = stats.time_elapsed
+
+    cts = stats.termination_status
+    ts, ps, ds = if cts == CoolPDLP.OPTIMAL
+        MOI.OPTIMAL, MOI.FEASIBLE_POINT, MOI.FEASIBLE_POINT
+    elseif cts == CoolPDLP.TIME_LIMIT
+        MOI.TIME_LIMIT, MOI.UNKNOWN_RESULT_STATUS, MOI.UNKNOWN_RESULT_STATUS
+    elseif cts == CoolPDLP.ITERATION_LIMIT
+        MOI.ITERATION_LIMIT, MOI.UNKNOWN_RESULT_STATUS, MOI.UNKNOWN_RESULT_STATUS
+    else
+        @assert cts == CoolPDLP.STILL_RUNNING
+        MOI.OTHER_ERROR, MOI.NO_SOLUTION, MOI.NO_SOLUTION
+    end
+    dest.termination_status = ts
+    dest.primal_status = ps
+    dest.dual_status = ds
+
+    return index_map, false
+end
+
+end

--- a/src/CoolPDLP.jl
+++ b/src/CoolPDLP.jl
@@ -54,4 +54,6 @@ export preprocess, initialize, solve, solve!
 export PDHG, PDLP
 export is_feasible, objective_value
 
+global Optimizer
+
 end # module CoolPDLP

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -191,6 +191,11 @@ function solve(
     starting_time = time()
     milp, sol = preprocess(milp_init_cpu, sol_init_cpu, algo)
     state = initialize(milp, sol, algo; starting_time)
+    if nbcons(milp) == 0 && all(iszero, milp.c) # early exit for 0 obj/no cons
+        @. sol.x = proj_box(zero(eltype(milp.lv)), milp.lv, milp.uv)
+        state.stats.termination_status = OPTIMAL
+        return get_solution(state, milp), state.stats
+    end
     solve!(state, milp, algo)
     return get_solution(state, milp), state.stats
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -2,6 +2,7 @@ using Test
 import MathOptInterface as MOI
 import CoolPDLP
 import JuMP
+using JLArrays: JLBackend
 
 @testset "MOI Test Suite" begin
     model = MOI.Bridges.full_bridge_optimizer(
@@ -33,4 +34,21 @@ import JuMP
             r"test_linear_add_constraints",
         ],
     )
+end
+
+@testset "JLBackend" begin
+    model = JuMP.Model(CoolPDLP.Optimizer)
+    JuMP.set_silent(model)
+    JuMP.set_attribute(model, "matrix_type", CoolPDLP.GPUSparseMatrixCSR)
+    JuMP.set_attribute(model, "backend", JLBackend())
+
+    JuMP.@variable(model, x >= 0)
+    JuMP.@variable(model, 0 <= y <= 3)
+    JuMP.@objective(model, Min, 12x + 20y)
+    JuMP.@constraint(model, c1, 6x + 8y >= 100)
+    JuMP.@constraint(model, c2, 7x + 12y >= 120)
+    JuMP.optimize!(model)
+    @test JuMP.termination_status(model) == MOI.OPTIMAL
+    @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
+    @test JuMP.objective_value(model) ≈ 205.0 atol = 1.0e-2
 end

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -15,17 +15,17 @@ import JuMP
     MOI.Test.runtests(
         model,
         MOI.Test.Config(;
-            atol=1e-3,
-            rtol=1e-3,
-            optimal_status=MOI.OPTIMAL,
-            exclude=Any[
+            atol = 1.0e-3,
+            rtol = 1.0e-3,
+            optimal_status = MOI.OPTIMAL,
+            exclude = Any[
                 MOI.ObjectiveBound,
                 MOI.VariableBasisStatus,
                 MOI.ConstraintBasisStatus,
                 MOI.DualObjectiveValue,
             ],
         );
-        exclude=[
+        exclude = [
             # TODO: infeasible/unbounded detection
             r"INFEASIB",
             r"unbounded",

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -71,15 +71,15 @@ end
     # model/return in Float32, solve in Float32
     model = JuMP.GenericModel{Float32}(CoolPDLP.Optimizer{Float32})
     JuMP.set_silent(model)
-    JuMP.@variable(model, x >= 0f0)
-    JuMP.@variable(model, 0f0 <= y <= 3f0)
-    JuMP.@objective(model, Min, 12f0x + 20f0y)
-    JuMP.@constraint(model, c1, 6f0x + 8f0y >= 100f0)
-    JuMP.@constraint(model, c2, 7f0x + 12f0y >= 120f0)
+    JuMP.@variable(model, x >= 0.0f0)
+    JuMP.@variable(model, 0.0f0 <= y <= 3.0f0)
+    JuMP.@objective(model, Min, 12.0f0x + 20.0f0y)
+    JuMP.@constraint(model, c1, 6.0f0x + 8.0f0y >= 100.0f0)
+    JuMP.@constraint(model, c2, 7.0f0x + 12.0f0y >= 120.0f0)
     JuMP.optimize!(model)
     @test JuMP.termination_status(model) == MOI.OPTIMAL
     @test JuMP.primal_status(model) == MOI.FEASIBLE_POINT
-    @test JuMP.objective_value(model) ≈ 205f0 atol = 1.0e-2
+    @test JuMP.objective_value(model) ≈ 205.0f0 atol = 1.0e-2
     @test JuMP.value(x) isa Float32
 end
 

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,0 +1,36 @@
+using Test
+import MathOptInterface as MOI
+import CoolPDLP
+import JuMP
+
+@testset "MOI Test Suite" begin
+    model = MOI.Bridges.full_bridge_optimizer(
+        MOI.Utilities.CachingOptimizer(
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+            CoolPDLP.Optimizer(),
+        ),
+        Float64,
+    )
+    MOI.set(model, MOI.Silent(), true)
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(;
+            atol=1e-3,
+            rtol=1e-3,
+            optimal_status=MOI.OPTIMAL,
+            exclude=Any[
+                MOI.ObjectiveBound,
+                MOI.VariableBasisStatus,
+                MOI.ConstraintBasisStatus,
+                MOI.DualObjectiveValue,
+            ],
+        );
+        exclude=[
+            # TODO: infeasible/unbounded detection
+            r"INFEASIB",
+            r"unbounded",
+            # Poor precision on this test
+            r"test_linear_add_constraints",
+        ],
+    )
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CoolPDLP = "9e90bdc5-3073-4e0f-a275-e19f28ac1b53"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,7 @@ using Test
             end
         end
     end
+    @testset "MOI Wrapper" begin
+        include("MOI_wrapper.jl")
+    end
 end

--- a/test/utils/linalg.jl
+++ b/test/utils/linalg.jl
@@ -50,8 +50,9 @@ end
 end
 
 @testset "Spectral norm" begin
+    rng = Xoshiro(42)
     for _ in 1:10
-        A = randn(10, 20)
+        A = randn(rng, 10, 20)
         s1 = CoolPDLP.spectral_norm(A, Matrix(transpose(A)); tol = 1.0e-7)
         s1_ref = opnorm(A, 2)
         @test s1 ≈ s1_ref rtol = 1.0e-1


### PR DESCRIPTION
Here is an initial MOI wrapper. It supports GPU, but it is non-incremental (so any modifications on the JuMP side will re-build the model from scratch).

I've verified that the CUDA test passes and uses the GPU.

fixes #14 