### PR TITLE
crossover:v0; first simple version for feedback

### DIFF
--- a/src/CoolPDLP.jl
+++ b/src/CoolPDLP.jl
@@ -42,6 +42,7 @@ include("public.jl")
     include("components/restart.jl")
     include("components/generic.jl")
     include("components/termination.jl")
+    include("components/crossover.jl")
 
     include("algorithms/common.jl")
     include("algorithms/pdhg.jl")

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -18,6 +18,7 @@ struct Algorithm{
     restart::RestartParameters{T}
     generic::GenericParameters
     termination::TerminationParameters{T}
+    crossover::CrossoverParameters{T}
 end
 
 """
@@ -46,6 +47,13 @@ end
         termination_reltol = 1.0e-4,
         max_kkt_passes = 10^5,
         time_limit = 100.0,
+        # crossover
+        crossover = true,
+        crossover_threshold = 1.0e-6,
+        crossover_fixed_tol = 1.0e-8,
+        crossover_rollback_on_kkt_regression = true,
+        crossover_kkt_rtol = 0.0,
+        crossover_use_effective_bounds = true,
     )
 
 Constructor for algorithm configs.
@@ -75,6 +83,13 @@ function Algorithm{A}(
         termination_reltol = 1.0e-4,
         max_kkt_passes = 10^5,
         time_limit = 100.0,
+        # crossover
+        crossover = true,
+        crossover_threshold = 1.0e-6,
+        crossover_fixed_tol = 1.0e-8,
+        crossover_rollback_on_kkt_regression = true,
+        crossover_kkt_rtol = 0.0,
+        crossover_use_effective_bounds = true,
     ) where {A, T, Ti, M, B}
 
     conversion = ConversionParameters(
@@ -104,6 +119,15 @@ function Algorithm{A}(
         max_kkt_passes,
         time_limit
     )
+    reltol_T = _T(termination_reltol)
+    crossover_params = CrossoverParameters(;
+        enabled = crossover,
+        threshold = max(_T(crossover_threshold), reltol_T / 20),
+        fixed_tol = _T(crossover_fixed_tol),
+        rollback_on_kkt_regression = crossover_rollback_on_kkt_regression,
+        kkt_rtol = _T(crossover_kkt_rtol),
+        use_effective_bounds = crossover_use_effective_bounds,
+    )
 
     return Algorithm{A, T, Ti, M, B}(
         conversion,
@@ -111,12 +135,13 @@ function Algorithm{A}(
         step_size,
         restart,
         generic,
-        termination
+        termination,
+        crossover_params
     )
 end
 
 function Base.show(io::IO, algo::Algorithm{A}) where {A}
-    (; conversion, preconditioning, step_size, restart, generic, termination) = algo
+    (; conversion, preconditioning, step_size, restart, generic, termination, crossover) = algo
     return print(
         io, """
         $A algorithm:
@@ -125,11 +150,54 @@ function Base.show(io::IO, algo::Algorithm{A}) where {A}
         - $step_size
         - $restart
         - $generic
-        - $termination"""
+        - $termination
+        - $crossover"""
     )
 end
 
 abstract type AbstractState{T, V} end
+
+"""
+    apply_crossover!(state, milp, algo)
+
+Apply [`crossover_threshold!`](@ref) when `algo.crossover.enabled` and termination is [`OPTIMAL`](@ref).
+
+Roll back to the pre-crossover primal when [`crossover_kkt_acceptable`](@ref) fails.
+Updates `state.stats.crossover_applied`, `crossover_rolled_back`, and `crossover_n_snapped`.
+"""
+function apply_crossover!(
+        state::AbstractState,
+        milp::MILP,
+        algo::Algorithm,
+    )
+    params = algo.crossover
+    stats = state.stats
+    if !params.enabled
+        stats.crossover_applied = false
+        stats.crossover_rolled_back = false
+        stats.crossover_n_snapped = 0
+        return nothing
+    end
+    (; termination_reltol) = algo.termination
+    err_before = stats.err
+    x_backup = copy(state.sol.x)
+    crossover_threshold!(state.sol, milp, params)
+    n_changed = crossover_n_changed(state.sol.x, x_backup)
+    err_after = kkt_errors!(state.scratch, state.sol, milp)
+    if n_changed > 0 &&
+            crossover_kkt_acceptable(err_before, err_after, termination_reltol, params)
+        stats.err = err_after
+        stats.crossover_applied = true
+        stats.crossover_rolled_back = false
+        stats.crossover_n_snapped = n_changed
+    else
+        state.sol.x .= x_backup
+        stats.crossover_applied = false
+        stats.crossover_rolled_back = n_changed > 0
+        stats.crossover_n_snapped = 0
+    end
+    return nothing
+end
 
 function prog_showvalues(state::AbstractState)
     err = state.stats.err
@@ -198,6 +266,9 @@ function solve(
         return get_solution(state, milp), state.stats
     end
     solve!(state, milp, algo)
+    if state.stats.termination_status == OPTIMAL
+        apply_crossover!(state, milp, algo)
+    end
     return get_solution(state, milp), state.stats
 end
 

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -160,7 +160,7 @@ abstract type AbstractState{T, V} end
 """
     apply_crossover!(state, milp, algo)
 
-Apply [`crossover_threshold!`](@ref) when `algo.crossover.enabled` and termination is [`OPTIMAL`](@ref).
+Apply [`crossover_threshold!`](@ref) when `algo.crossover.enabled` and termination is `TerminationStatus.OPTIMAL`.
 
 Roll back to the pre-crossover primal when [`crossover_kkt_acceptable`](@ref) fails.
 Updates `state.stats.crossover_applied`, `crossover_rolled_back`, and `crossover_n_snapped`.

--- a/src/algorithms/common.jl
+++ b/src/algorithms/common.jl
@@ -47,16 +47,23 @@ end
         termination_reltol = 1.0e-4,
         max_kkt_passes = 10^5,
         time_limit = 100.0,
-        # crossover
+        # crossover (defaults are pragmatic V1 knobs; threshold is floored at reltol/20 below)
         crossover = true,
         crossover_threshold = 1.0e-6,
         crossover_fixed_tol = 1.0e-8,
         crossover_rollback_on_kkt_regression = true,
         crossover_kkt_rtol = 0.0,
         crossover_use_effective_bounds = true,
+        crossover_bound_atol = 1.0e-12,
+        crossover_eq_atol = 1.0e-12,
     )
 
 Constructor for algorithm configs.
+
+Crossover defaults: `crossover_threshold` and `crossover_fixed_tol` are small absolute
+snapping tolerances (similar order to cuPDLPx / PDLP post-process heuristics). The
+effective snap threshold is `max(crossover_threshold, termination_reltol / 20)` so
+crossover does not fire far from optimality when `reltol` is loose.
 """
 function Algorithm{A}(
         # conversion
@@ -90,6 +97,8 @@ function Algorithm{A}(
         crossover_rollback_on_kkt_regression = true,
         crossover_kkt_rtol = 0.0,
         crossover_use_effective_bounds = true,
+        crossover_bound_atol = 1.0e-12,
+        crossover_eq_atol = 1.0e-12,
     ) where {A, T, Ti, M, B}
 
     conversion = ConversionParameters(
@@ -127,6 +136,8 @@ function Algorithm{A}(
         rollback_on_kkt_regression = crossover_rollback_on_kkt_regression,
         kkt_rtol = _T(crossover_kkt_rtol),
         use_effective_bounds = crossover_use_effective_bounds,
+        bound_atol = _T(crossover_bound_atol),
+        eq_atol = _T(crossover_eq_atol),
     )
 
     return Algorithm{A, T, Ti, M, B}(

--- a/src/components/crossover.jl
+++ b/src/components/crossover.jl
@@ -1,7 +1,7 @@
 """
     CrossoverParameters
 
-Post-solve crossover settings: threshold snapping to bounds after [`OPTIMAL`](@ref) termination.
+Post-solve crossover settings: threshold snapping to bounds after `TerminationStatus.OPTIMAL` termination.
 
 See [`crossover_threshold!`](@ref) and [`apply_crossover!`](@ref).
 

--- a/src/components/crossover.jl
+++ b/src/components/crossover.jl
@@ -1,0 +1,239 @@
+"""
+    CrossoverParameters
+
+Post-solve crossover settings: threshold snapping to bounds after [`OPTIMAL`](@ref) termination.
+
+See [`crossover_threshold!`](@ref) and [`apply_crossover!`](@ref).
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+@kwdef struct CrossoverParameters{T <: Number}
+    "whether to apply crossover after PDLP/PDHG terminates optimally"
+    enabled::Bool = true
+    "distance to a bound below which the primal is snapped to that bound"
+    threshold::T = 1.0e-6
+    "tolerance for treating lower and upper bounds as equal (fixed variable)"
+    fixed_tol::T = 1.0e-8
+    "revert to the pre-crossover primal if KKT errors regress beyond tolerances"
+    rollback_on_kkt_regression::Bool = true
+    "relative KKT increase tolerated above the pre-crossover value (0 = no increase)"
+    kkt_rtol::T = 0.0
+    "tighten infinite bounds from equality rows before snapping"
+    use_effective_bounds::Bool = true
+end
+
+function Base.show(io::IO, params::CrossoverParameters)
+    (; enabled, threshold, fixed_tol, rollback_on_kkt_regression, kkt_rtol, use_effective_bounds) = params
+    return print(
+        io,
+        "CrossoverParameters: enabled=$enabled, threshold=$threshold, fixed_tol=$fixed_tol, ",
+        "rollback_on_kkt_regression=$rollback_on_kkt_regression, kkt_rtol=$kkt_rtol, ",
+        "use_effective_bounds=$use_effective_bounds",
+    )
+end
+
+"""
+    crossover_kkt_acceptable(err_before, err_after, termination_reltol, params)
+
+Return `true` if the post-crossover KKT errors should be kept.
+
+When `rollback_on_kkt_regression` is true, reject the crossover if either:
+- `relative(err_after) > termination_reltol`, or
+- `relative(err_after) > relative(err_before) * (1 + kkt_rtol)`.
+"""
+function crossover_kkt_acceptable(
+        err_before::KKTErrors,
+        err_after::KKTErrors,
+        termination_reltol,
+        params::CrossoverParameters,
+    )
+    params.rollback_on_kkt_regression || return true
+    rel_before = relative(err_before)
+    rel_after = relative(err_after)
+    rel_after <= termination_reltol || return false
+    rel_after <= rel_before * (1 + params.kkt_rtol) || return false
+    return true
+end
+
+function _crossover_at_box_mask(
+        x::AbstractVector,
+        lv::AbstractVector,
+        uv::AbstractVector;
+        atol::Real = 1.0e-12,
+    )
+    at_l = isfinite.(lv) .& (abs.(x .- lv) .<= atol)
+    at_u = isfinite.(uv) .& (abs.(x .- uv) .<= atol)
+    return at_l .| at_u
+end
+
+function _crossover_cpu_milp(milp::MILP)
+    milp_csc = set_matrix_type(SparseMatrixCSC, milp)
+    return adapt(CPU(), milp_csc)
+end
+
+"""
+    crossover_effective_bounds(milp, x)
+
+Box bounds tightened with implied limits from equality rows.
+
+When an equality row has exactly one variable not yet on a finite box bound, that
+row's implied bound is used to fill in an infinite bound (e.g. `x₁ ≤ 1` from
+`x₁ + x₂ = 1` when `x₂` is already on its lower bound).
+
+Computed on CPU and copied back to the device of `milp.lv` / `milp.uv`.
+"""
+function crossover_effective_bounds(
+        milp::MILP{T},
+        x::AbstractVector{T};
+        bound_atol::Real = 1.0e-12,
+        eq_atol::Real = 1.0e-12,
+    ) where {T}
+    lv_eff = copy(milp.lv)
+    uv_eff = copy(milp.uv)
+    milp_cpu = _crossover_cpu_milp(milp)
+    x_cpu = Vector(x)
+    lv_cpu = Vector(lv_eff)
+    uv_cpu = Vector(uv_eff)
+    at_box = Vector(
+        _crossover_at_box_mask(x_cpu, Vector(milp_cpu.lv), Vector(milp_cpu.uv); atol = bound_atol),
+    )
+    _crossover_effective_bounds!(
+        lv_cpu,
+        uv_cpu,
+        milp_cpu.A,
+        Vector(milp_cpu.lc),
+        Vector(milp_cpu.uc),
+        x_cpu,
+        at_box;
+        eq_atol,
+    )
+    backend = get_backend(lv_eff)
+    copyto!(lv_eff, adapt(backend, lv_cpu))
+    copyto!(uv_eff, adapt(backend, uv_cpu))
+    return lv_eff, uv_eff
+end
+
+function _crossover_effective_bounds!(
+        lv_eff,
+        uv_eff,
+        A::SparseMatrixCSC{T},
+        lc,
+        uc,
+        x,
+        at_box;
+        eq_atol::Real = 1.0e-12,
+    ) where {T}
+    m, n = size(A)
+    lc_cpu = Vector(lc)
+    uc_cpu = Vector(uc)
+    x_cpu = Vector(x)
+    lv_cpu = Vector(lv_eff)
+    uv_cpu = Vector(uv_eff)
+    at_box_cpu = Vector(at_box)
+    for i in 1:m
+        isapprox(lc_cpu[i], uc_cpu[i]; atol = eq_atol) || continue
+        free = Int[]
+        slack = lc_cpu[i]
+        @inbounds for j in 1:n
+            aij = A[i, j]
+            aij == 0 && continue
+            if at_box_cpu[j]
+                slack -= aij * x_cpu[j]
+            else
+                push!(free, j)
+            end
+        end
+        length(free) == 1 || continue
+        j = only(free)
+        aij = A[i, j]
+        if aij > 0
+            implied = slack / aij
+            if !isfinite(uv_cpu[j])
+                uv_cpu[j] = implied
+            else
+                uv_cpu[j] = min(uv_cpu[j], implied)
+            end
+        elseif aij < 0
+            implied = slack / aij
+            if !isfinite(lv_cpu[j])
+                lv_cpu[j] = implied
+            else
+                lv_cpu[j] = max(lv_cpu[j], implied)
+            end
+        end
+    end
+    lv_eff .= lv_cpu
+    uv_eff .= uv_cpu
+    return lv_eff, uv_eff
+end
+
+"""
+    crossover_threshold!(x, lv, uv, params::CrossoverParameters)
+
+Snap primal `x` to variable bounds using a fixed threshold.
+
+For each coordinate: fixed variables are set to their bound; otherwise, if `x` is
+within `threshold` of a finite lower or upper bound, it is moved to that bound.
+"""
+function crossover_threshold!(
+        x::AbstractVector{T},
+        lv::AbstractVector{T},
+        uv::AbstractVector{T},
+        params::CrossoverParameters{T},
+    ) where {T}
+    (; threshold, fixed_tol) = params
+    fixed = abs.(lv .- uv) .<= fixed_tol
+    @. x = ifelse(fixed, lv, x)
+    near_l = isfinite.(lv) .& (x .- lv .<= threshold)
+    @. x = ifelse(near_l, lv, x)
+    near_u = isfinite.(uv) .& (uv .- x .<= threshold)
+    @. x = ifelse(near_u, uv, x)
+    return x
+end
+
+function crossover_threshold!(
+        x::AbstractVector{T},
+        milp::MILP{T},
+        params::CrossoverParameters{T},
+    ) where {T}
+    if params.use_effective_bounds
+        lv_eff, uv_eff = crossover_effective_bounds(milp, x)
+    else
+        lv_eff, uv_eff = milp.lv, milp.uv
+    end
+    crossover_threshold!(x, lv_eff, uv_eff, params)
+    return x
+end
+
+function crossover_threshold!(
+        sol::PrimalDualSolution{T},
+        milp::MILP{T},
+        params::CrossoverParameters{T},
+    ) where {T}
+    crossover_threshold!(sol.x, milp, params)
+    return sol
+end
+
+function crossover_n_changed(x_after, x_before)
+    return sum(x_after .!= x_before)
+end
+
+"""
+    fraction_at_bounds(x, milp; atol=1e-12)
+
+Fraction of coordinates equal to a finite bound.
+"""
+function fraction_at_bounds(
+        x::AbstractVector,
+        milp::MILP;
+        atol::Real = 1.0e-12,
+    )
+    (; lv, uv) = milp
+    n = length(x)
+    n == 0 && return 0.0
+    at_l = isfinite.(lv) .& (abs.(x .- lv) .<= atol)
+    at_u = isfinite.(uv) .& (abs.(x .- uv) .<= atol)
+    return sum(at_l .| at_u) / n
+end

--- a/src/components/crossover.jl
+++ b/src/components/crossover.jl
@@ -80,7 +80,6 @@ function _crossover_at_box_mask(
 end
 
 function _crossover_cpu_milp(milp::MILP)
-    # GPU / CSR MILPs: run implied-bounds logic on CPU CSC (row access via `At` columns).
     milp_csc = set_matrix_type(SparseMatrixCSC, milp)
     return adapt(CPU(), milp_csc)
 end
@@ -91,8 +90,9 @@ end
 Box bounds tightened with implied limits from equality rows.
 
 When an equality row has exactly one variable not yet on a finite box bound, that
-row's implied bound is used to fill in an infinite bound (e.g. `x₁ ≤ 1` from
-`x₁ + x₂ = 1` when `x₂` is already on its lower bound).
+row is solved for the free variable and the implied limit is applied with
+`min`/`max` on its box (fills `±Inf` or tightens an already finite bound).
+Example: `x₁ ≤ 1` from `x₁ + x₂ = 1` when `x₂` is already on its lower bound.
 
 Computed on CPU and copied back to the device of `milp.lv` / `milp.uv`.
 """
@@ -141,33 +141,27 @@ function crossover_effective_bounds(
 end
 
 function _crossover_effective_bounds!(
-        lv_eff,
-        uv_eff,
+        lv_eff::AbstractVector{T},
+        uv_eff::AbstractVector{T},
         At::SparseMatrixCSC{T},
-        lc,
-        uc,
-        x,
-        at_box;
+        lc::AbstractVector,
+        uc::AbstractVector,
+        x::AbstractVector,
+        at_box::AbstractVector;
         eq_atol::Real = 1.0e-12,
     ) where {T}
     m = size(At, 2)
-    lc_cpu = Vector(lc)
-    uc_cpu = Vector(uc)
-    x_cpu = Vector(x)
-    lv_cpu = Vector(lv_eff)
-    uv_cpu = Vector(uv_eff)
-    at_box_cpu = Vector(at_box)
     for i in 1:m
-        isapprox(lc_cpu[i], uc_cpu[i]; atol = eq_atol) || continue
-        slack = lc_cpu[i]
+        isapprox(lc[i], uc[i]; atol = eq_atol) || continue
+        slack = lc[i]
         free_j = 0
         free_aij = zero(T)
         n_free = 0
         for ptr in nzrange(At, i)
             j = SparseArrays.rowvals(At)[ptr]
             aij = nonzeros(At)[ptr]
-            if at_box_cpu[j]
-                slack -= aij * x_cpu[j]
+            if at_box[j]
+                slack -= aij * x[j]
             else
                 n_free += 1
                 n_free > 1 && break
@@ -177,13 +171,11 @@ function _crossover_effective_bounds!(
         end
         n_free == 1 || continue
         if free_aij > 0
-            uv_cpu[free_j] = min(uv_cpu[free_j], slack / free_aij)
+            uv_eff[free_j] = min(uv_eff[free_j], slack / free_aij)
         elseif free_aij < 0
-            lv_cpu[free_j] = max(lv_cpu[free_j], slack / free_aij)
+            lv_eff[free_j] = max(lv_eff[free_j], slack / free_aij)
         end
     end
-    lv_eff .= lv_cpu
-    uv_eff .= uv_cpu
     return lv_eff, uv_eff
 end
 

--- a/src/components/crossover.jl
+++ b/src/components/crossover.jl
@@ -1,7 +1,13 @@
 """
     CrossoverParameters
 
-Post-solve crossover settings: threshold snapping to bounds after `TerminationStatus.OPTIMAL` termination.
+Post-solve crossover (V1): after `TerminationStatus.OPTIMAL`, snap primal coordinates
+near finite box bounds and optionally tighten bounds implied by equality rows.
+
+This is **not** a basic-vertex crossover (no simplex basis / Megiddo pivots). It is a
+lightweight rounding step related to PDLP post-processing and MIP-ready primals; see
+issue #13 and the draft note in the PR. A full Megiddo-style crossover is planned
+separately.
 
 See [`crossover_threshold!`](@ref) and [`apply_crossover!`](@ref).
 
@@ -22,15 +28,20 @@ $(TYPEDFIELDS)
     kkt_rtol::T = 0.0
     "tighten infinite bounds from equality rows before snapping"
     use_effective_bounds::Bool = true
+    "tolerance for treating a coordinate as on a finite box bound"
+    bound_atol::T = 1.0e-12
+    "tolerance for treating a constraint row as an equality"
+    eq_atol::T = 1.0e-12
 end
 
 function Base.show(io::IO, params::CrossoverParameters)
-    (; enabled, threshold, fixed_tol, rollback_on_kkt_regression, kkt_rtol, use_effective_bounds) = params
+    (; enabled, threshold, fixed_tol, rollback_on_kkt_regression, kkt_rtol, use_effective_bounds, bound_atol, eq_atol) =
+        params
     return print(
         io,
         "CrossoverParameters: enabled=$enabled, threshold=$threshold, fixed_tol=$fixed_tol, ",
         "rollback_on_kkt_regression=$rollback_on_kkt_regression, kkt_rtol=$kkt_rtol, ",
-        "use_effective_bounds=$use_effective_bounds",
+        "use_effective_bounds=$use_effective_bounds, bound_atol=$bound_atol, eq_atol=$eq_atol",
     )
 end
 
@@ -69,6 +80,7 @@ function _crossover_at_box_mask(
 end
 
 function _crossover_cpu_milp(milp::MILP)
+    # GPU / CSR MILPs: run implied-bounds logic on CPU CSC (row access via `At` columns).
     milp_csc = set_matrix_type(SparseMatrixCSC, milp)
     return adapt(CPU(), milp_csc)
 end
@@ -86,10 +98,10 @@ Computed on CPU and copied back to the device of `milp.lv` / `milp.uv`.
 """
 function crossover_effective_bounds(
         milp::MILP{T},
-        x::AbstractVector{T};
-        bound_atol::Real = 1.0e-12,
-        eq_atol::Real = 1.0e-12,
+        x::AbstractVector{T},
+        params::CrossoverParameters{T},
     ) where {T}
+    (; bound_atol, eq_atol) = params
     lv_eff = copy(milp.lv)
     uv_eff = copy(milp.uv)
     milp_cpu = _crossover_cpu_milp(milp)
@@ -97,14 +109,14 @@ function crossover_effective_bounds(
     lv_cpu = Vector(lv_eff)
     uv_cpu = Vector(uv_eff)
     at_box = Vector(
-        _crossover_at_box_mask(x_cpu, Vector(milp_cpu.lv), Vector(milp_cpu.uv); atol = bound_atol),
+        _crossover_at_box_mask(x_cpu, milp_cpu.lv, milp_cpu.uv; atol = bound_atol),
     )
     _crossover_effective_bounds!(
         lv_cpu,
         uv_cpu,
-        milp_cpu.A,
-        Vector(milp_cpu.lc),
-        Vector(milp_cpu.uc),
+        milp_cpu.At,
+        milp_cpu.lc,
+        milp_cpu.uc,
         x_cpu,
         at_box;
         eq_atol,
@@ -115,17 +127,30 @@ function crossover_effective_bounds(
     return lv_eff, uv_eff
 end
 
+function crossover_effective_bounds(
+        milp::MILP{T},
+        x::AbstractVector{T};
+        bound_atol::Real = 1.0e-12,
+        eq_atol::Real = 1.0e-12,
+    ) where {T}
+    return crossover_effective_bounds(
+        milp,
+        x,
+        CrossoverParameters{T}(; bound_atol = T(bound_atol), eq_atol = T(eq_atol)),
+    )
+end
+
 function _crossover_effective_bounds!(
         lv_eff,
         uv_eff,
-        A::SparseMatrixCSC{T},
+        At::SparseMatrixCSC{T},
         lc,
         uc,
         x,
         at_box;
         eq_atol::Real = 1.0e-12,
     ) where {T}
-    m, n = size(A)
+    m = size(At, 2)
     lc_cpu = Vector(lc)
     uc_cpu = Vector(uc)
     x_cpu = Vector(x)
@@ -134,34 +159,27 @@ function _crossover_effective_bounds!(
     at_box_cpu = Vector(at_box)
     for i in 1:m
         isapprox(lc_cpu[i], uc_cpu[i]; atol = eq_atol) || continue
-        free = Int[]
         slack = lc_cpu[i]
-        @inbounds for j in 1:n
-            aij = A[i, j]
-            aij == 0 && continue
+        free_j = 0
+        free_aij = zero(T)
+        n_free = 0
+        for ptr in nzrange(At, i)
+            j = SparseArrays.rowvals(At)[ptr]
+            aij = nonzeros(At)[ptr]
             if at_box_cpu[j]
                 slack -= aij * x_cpu[j]
             else
-                push!(free, j)
+                n_free += 1
+                n_free > 1 && break
+                free_j = j
+                free_aij = aij
             end
         end
-        length(free) == 1 || continue
-        j = only(free)
-        aij = A[i, j]
-        if aij > 0
-            implied = slack / aij
-            if !isfinite(uv_cpu[j])
-                uv_cpu[j] = implied
-            else
-                uv_cpu[j] = min(uv_cpu[j], implied)
-            end
-        elseif aij < 0
-            implied = slack / aij
-            if !isfinite(lv_cpu[j])
-                lv_cpu[j] = implied
-            else
-                lv_cpu[j] = max(lv_cpu[j], implied)
-            end
+        n_free == 1 || continue
+        if free_aij > 0
+            uv_cpu[free_j] = min(uv_cpu[free_j], slack / free_aij)
+        elseif free_aij < 0
+            lv_cpu[free_j] = max(lv_cpu[free_j], slack / free_aij)
         end
     end
     lv_eff .= lv_cpu
@@ -199,7 +217,7 @@ function crossover_threshold!(
         params::CrossoverParameters{T},
     ) where {T}
     if params.use_effective_bounds
-        lv_eff, uv_eff = crossover_effective_bounds(milp, x)
+        lv_eff, uv_eff = crossover_effective_bounds(milp, x, params)
     else
         lv_eff, uv_eff = milp.lv, milp.uv
     end
@@ -217,6 +235,13 @@ function crossover_threshold!(
 end
 
 function crossover_n_changed(x_after, x_before)
+    if get_backend(x_after) === CPU()
+        n = 0
+        for i in eachindex(x_after, x_before)
+            x_after[i] != x_before[i] && (n += 1)
+        end
+        return n
+    end
     return sum(x_after .!= x_before)
 end
 

--- a/src/components/termination.jl
+++ b/src/components/termination.jl
@@ -95,7 +95,6 @@ function Base.show(io::IO, stats::ConvergenceStats)
     elseif crossover_applied
         "crossover applied ($crossover_n_snapped coords)"
     else
-        # crossover disabled, no coordinates changed, or rollback with n_changed == 0
         "crossover not applied"
     end
     return print(

--- a/src/components/termination.jl
+++ b/src/components/termination.jl
@@ -95,6 +95,7 @@ function Base.show(io::IO, stats::ConvergenceStats)
     elseif crossover_applied
         "crossover applied ($crossover_n_snapped coords)"
     else
+        # crossover disabled, no coordinates changed, or rollback with n_changed == 0
         "crossover not applied"
     end
     return print(

--- a/src/components/termination.jl
+++ b/src/components/termination.jl
@@ -54,6 +54,12 @@ mutable struct ConvergenceStats{T <: Number}
     termination_status::TerminationStatus
     "history of KKT errors, indexed by number of KKT passes"
     const error_history::Vector{Tuple{Int, KKTErrors{T}}}
+    "true if the last crossover was applied and kept"
+    crossover_applied::Bool
+    "true if the last crossover was reverted to preserve KKT quality"
+    crossover_rolled_back::Bool
+    "number of primal coordinates snapped and kept by the last crossover"
+    crossover_n_snapped::Int
 
     function ConvergenceStats(
             ::Type{T};
@@ -62,7 +68,10 @@ mutable struct ConvergenceStats{T <: Number}
             time_elapsed = 0.0,
             kkt_passes = 0,
             termination_status = STILL_RUNNING,
-            error_history = Tuple{Int, KKTErrors{T}}[]
+            error_history = Tuple{Int, KKTErrors{T}}[],
+            crossover_applied = false,
+            crossover_rolled_back = false,
+            crossover_n_snapped = 0,
         ) where {T}
         return new{T}(
             err,
@@ -70,19 +79,31 @@ mutable struct ConvergenceStats{T <: Number}
             time_elapsed,
             kkt_passes,
             termination_status,
-            error_history
+            error_history,
+            crossover_applied,
+            crossover_rolled_back,
+            crossover_n_snapped,
         )
     end
 end
 
 function Base.show(io::IO, stats::ConvergenceStats)
-    (; err, time_elapsed, kkt_passes, termination_status) = stats
+    (; err, time_elapsed, kkt_passes, termination_status, crossover_applied, crossover_rolled_back, crossover_n_snapped) =
+        stats
+    xover = if crossover_rolled_back
+        "crossover rolled back"
+    elseif crossover_applied
+        "crossover applied ($crossover_n_snapped coords)"
+    else
+        "crossover not applied"
+    end
     return print(
         io,
         """Convergence stats with termination status $termination_status:
         - $err
         - time elapsed: $(round(time_elapsed; digits = 3)) seconds 
-        - KKT passes: $kkt_passes""",
+        - KKT passes: $kkt_passes
+        - $xover""",
     )
 end
 

--- a/test/components/crossover.jl
+++ b/test/components/crossover.jl
@@ -1,0 +1,180 @@
+using CoolPDLP
+using LinearAlgebra
+using Random
+using SparseArrays
+using Test
+
+const _PDLP_TEST_KW = (;
+    termination_reltol = 1.0e-4,
+    max_kkt_passes = 200_000,
+    show_progress = false,
+    check_every = 10,
+)
+
+function _kkt_err(primal, dual, gap)
+    return CoolPDLP.KKTErrors(;
+        primal,
+        primal_scale = 1.0,
+        dual,
+        dual_scale = 1.0,
+        gap,
+        gap_scale = 1.0,
+    )
+end
+
+const _TOY_LP = MILP(;
+    c = [1.0, 2.0],
+    lv = [0.0, 0.0],
+    uv = [Inf, Inf],
+    A = sparse([1.0 1.0]),
+    lc = [1.0],
+    uc = [1.0],
+)
+
+const _BOX_LP = MILP(;
+    c = [1.0, 2.0],
+    lv = [0.0, 0.0],
+    uv = [1.0, 1.0],
+    A = sparse([1.0 1.0]),
+    lc = [1.0],
+    uc = [1.0],
+)
+
+@testset "crossover_threshold!" begin
+    x = [0.5, 0.999999, 2.0]
+    params = CoolPDLP.CrossoverParameters(; threshold = 1.0e-5)
+    CoolPDLP.crossover_threshold!(x, [0.0, 0.0, -Inf], [1.0, 1.0, Inf], params)
+    @test x == [0.5, 1.0, 2.0]
+
+    x = [1.0 - 1.0e-7, 1.0e-7]
+    CoolPDLP.crossover_threshold!(x, _BOX_LP, params)
+    @test x ≈ [1.0, 0.0]
+end
+
+@testset "crossover_effective_bounds" begin
+    x = [1.0 - 1.0e-7, 0.0]
+    _, uv = CoolPDLP.crossover_effective_bounds(_TOY_LP, x)
+    @test isapprox(uv[1], 1.0; atol = 1.0e-12)
+    @test isinf(uv[2])
+
+    milp_neg = MILP(;
+        c = [1.0, 1.0],
+        lv = [-Inf, 0.0],
+        uv = [Inf, 1.0],
+        A = sparse([-1.0 1.0]),
+        lc = [1.0],
+        uc = [1.0],
+    )
+    lv_neg, _ = CoolPDLP.crossover_effective_bounds(milp_neg, [0.5, 1.0])
+    @test isapprox(lv_neg[1], 0.0; atol = 1.0e-12)
+
+    milp_min = MILP(;
+        c = [1.0, 2.0],
+        lv = [0.0, 0.0],
+        uv = [0.5, Inf],
+        A = sparse([1.0 1.0]),
+        lc = [1.0],
+        uc = [1.0],
+    )
+    _, uv_min = CoolPDLP.crossover_effective_bounds(milp_min, x)
+    @test isapprox(uv_min[1], 0.5; atol = 1.0e-12)
+
+    milp_multi = MILP(;
+        c = ones(3),
+        lv = zeros(3),
+        uv = fill(Inf, 3),
+        A = sparse([1.0 1.0 1.0]),
+        lc = [1.0],
+        uc = [1.0],
+    )
+    lv_m, uv_m = CoolPDLP.crossover_effective_bounds(milp_multi, [0.2, 0.3, 0.5])
+    @test lv_m == milp_multi.lv && uv_m == milp_multi.uv
+
+    using Adapt
+    using JLArrays: JLBackend
+    milp_gpu = adapt(JLBackend(), CoolPDLP.set_matrix_type(CoolPDLP.GPUSparseMatrixCSR, _TOY_LP))
+    x_gpu = adapt(JLBackend(), x)
+    _, uv_gpu = CoolPDLP.crossover_effective_bounds(milp_gpu, x_gpu)
+    @test isapprox(Array(uv_gpu)[1], 1.0; atol = 1.0e-12)
+end
+
+@testset "crossover_kkt_acceptable and rollback" begin
+    err_lo = _kkt_err(1.0e-5, 1.0e-5, 1.0e-5)
+    err_hi = _kkt_err(2.0e-4, 2.0e-4, 2.0e-4)
+    err_mid = _kkt_err(1.05e-5, 1.05e-5, 1.05e-5)
+    tol = 1.0e-4
+    strict = CoolPDLP.CrossoverParameters(; rollback_on_kkt_regression = true, kkt_rtol = 0.0)
+    slack = CoolPDLP.CrossoverParameters(; rollback_on_kkt_regression = true, kkt_rtol = 0.1)
+
+    @test CoolPDLP.crossover_kkt_acceptable(err_lo, err_lo, tol, strict)
+    @test !CoolPDLP.crossover_kkt_acceptable(err_lo, err_hi, tol, strict)
+    @test CoolPDLP.crossover_kkt_acceptable(err_lo, err_mid, tol, slack)
+    @test CoolPDLP.crossover_kkt_acceptable(
+        err_lo,
+        err_hi,
+        tol,
+        CoolPDLP.CrossoverParameters(; rollback_on_kkt_regression = false),
+    )
+
+    milp = MILP(;
+        c = [0.0, 1.0],
+        lv = [0.0, 0.0],
+        uv = [1.0, 1.0],
+        A = sparse([1.0 1.0]),
+        lc = [0.6],
+        uc = [0.6],
+    )
+    algo_kw = (;
+        crossover = true,
+        crossover_threshold = 0.5,
+        crossover_use_effective_bounds = false,
+        _PDLP_TEST_KW...,
+    )
+    Random.seed!(123)
+    _, stats_rb = solve(milp, PDLP(; crossover_rollback_on_kkt_regression = true, algo_kw...))
+    Random.seed!(123)
+    _, stats_no = solve(
+        milp,
+        PDLP(; crossover_rollback_on_kkt_regression = false, algo_kw...),
+    )
+    @test stats_rb.crossover_rolled_back && !stats_rb.crossover_applied
+    @test stats_no.crossover_applied && !stats_no.crossover_rolled_back
+    @test CoolPDLP.relative(stats_rb.err) <= tol
+end
+
+@testset "crossover on solve" begin
+    Random.seed!(42)
+    sol_off, stats_off = solve(_TOY_LP, PDLP(; crossover = false, _PDLP_TEST_KW...))
+    Random.seed!(42)
+    sol_on, stats_on = solve(_TOY_LP, PDLP(; crossover = true, _PDLP_TEST_KW...))
+    x_off, x_on = Array(sol_off.x), Array(sol_on.x)
+
+    @test stats_on.termination_status == CoolPDLP.OPTIMAL
+    @test stats_on.crossover_applied
+    @test stats_on.crossover_n_snapped >= 1
+    @test !stats_on.crossover_rolled_back
+    @test x_on[1] ≈ 1.0 atol = 1.0e-12
+    @test x_on[1] > x_off[1]
+    @test CoolPDLP.is_feasible(x_on, _TOY_LP; cons_tol = 1.0e-5, verbose = false)
+
+    sol_box, stats_box = solve(_BOX_LP, PDLP(; crossover = true, _PDLP_TEST_KW...))
+    @test stats_box.termination_status == CoolPDLP.OPTIMAL
+    @test CoolPDLP.fraction_at_bounds(Array(sol_box.x), _BOX_LP) == 1.0
+    @test !stats_box.crossover_rolled_back
+
+    _, stats_disabled = solve(_BOX_LP, PDLP(; crossover = false, _PDLP_TEST_KW...))
+    @test !stats_disabled.crossover_applied
+    @test stats_disabled.crossover_n_snapped == 0
+end
+
+@testset "crossover_n_changed" begin
+    @test CoolPDLP.crossover_n_changed([1.0, 2.0], [1.0, 2.0]) == 0
+    @test CoolPDLP.crossover_n_changed([1.0, 0.0], [1.0, 2.0]) == 1
+
+    using Adapt
+    using JLArrays: JLBackend
+    x_before = adapt(JLBackend(), [1.0, 2.0])
+    x_after = copy(x_before)
+    x_after .= [1.0, 0.0]
+    @test CoolPDLP.crossover_n_changed(x_after, x_before) == 1
+end

--- a/test/components/crossover.jl
+++ b/test/components/crossover.jl
@@ -167,6 +167,17 @@ end
     @test stats_disabled.crossover_n_snapped == 0
 end
 
+@testset "ConvergenceStats show" begin
+    stats = CoolPDLP.ConvergenceStats(Float64)
+    @test occursin("crossover not applied", sprint(show, stats))
+    stats.crossover_applied = true
+    stats.crossover_n_snapped = 3
+    @test occursin("crossover applied (3 coords)", sprint(show, stats))
+    stats.crossover_applied = false
+    stats.crossover_rolled_back = true
+    @test occursin("crossover rolled back", sprint(show, stats))
+end
+
 @testset "crossover_n_changed" begin
     @test CoolPDLP.crossover_n_changed([1.0, 2.0], [1.0, 2.0]) == 0
     @test CoolPDLP.crossover_n_changed([1.0, 0.0], [1.0, 2.0]) == 1


### PR DESCRIPTION
Add V1 post-solve crossover (threshold snap + implied bounds) Refs #13

Post-OPTIMAL crossover for PDLP: snap primal coordinates near finite box bounds, tighten implied bounds from equality rows, rollback if KKT residuals regress. Controlled by CrossoverParameters on Algorithm (enabled by default).

V1 is not a basic-vertex crossover (unlike cuOpt): it helps near-bound / implied-bound cases (e.g. toy_lp) but is usually a no-op when variables stay strictly interior. Lightweight first step toward MIP-ready solutions.

Also realized a small bench compared to cuopt:
<img width="607" height="397" alt="speed_comparison" src="https://github.com/user-attachments/assets/52361706-a1a7-485d-bbba-340dee1056a6" />
I am planning a more advanced version cuopt-like after feedbacks