### PR TITLE
Revert "work around CUDA hangs on 1.10 (#57)"

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,25 +39,7 @@ GROUP = get(ENV, "COOLPDLP_TEST_GROUP", nothing)
         end
     end
     if GROUP == "CUDA"
-        Pkg.add(
-            [
-                Pkg.PackageSpec(name = "CUDA", rev = "main"),
-                Pkg.PackageSpec(name = "CUDACore", rev = "main"),
-                Pkg.PackageSpec(name = "CUDATools", rev = "main"),
-                Pkg.PackageSpec(name = "CUPTI", rev = "main"),
-                Pkg.PackageSpec(name = "NVML", rev = "main"),
-                Pkg.PackageSpec(name = "cuBLAS", rev = "main"),
-                Pkg.PackageSpec(name = "cuSPARSE", rev = "main"),
-                Pkg.PackageSpec(name = "cuSOLVER", rev = "main"),
-                Pkg.PackageSpec(name = "cuFFT", rev = "main"),
-                Pkg.PackageSpec(name = "cuRAND", rev = "main"),
-                Pkg.PackageSpec(name = "cuDNN", rev = "main"),
-                Pkg.PackageSpec(name = "cuTENSOR", rev = "main"),
-                Pkg.PackageSpec(name = "cuTensorNet", rev = "main"),
-                Pkg.PackageSpec(name = "cuStateVec", rev = "main"),
-                Pkg.PackageSpec(name = "GPUCompiler", rev = "main"),
-            ]
-        )
+        Pkg.add("CUDA")
         @testset verbose = true "CUDA" begin
             include("cuda/runtests.jl")
         end


### PR DESCRIPTION
Tim backported the fix to GPUCompiler 1.17, so this shouldn't be needed anymore. Let's see what CI says
