### PR TITLE
don't report coverage from 1.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,21 +2,39 @@ env:
   SECRET_CODECOV_TOKEN: "QlZXG5FfYRWvyLVclOLJxpbrOk6Jggxl7WOp3hmirkZ2Og4UP4r6ZCeUG6PAY+SvAxlQipwunhb3ydoGzgkZiTm0z0nIpieU8SGJRlF4aK80ytBI8t5MVVZFNHDvfKTLTPIJOSxzF2+jRDhhw/5on+a/zTUp9Qk3akzOg5r7owKiDQbJtzabVsWVSDpy7a8pu1IITNI1Ijt1hl+mbnCD1gSiZKm6uSAOYAlsygED3Sd3PDfV3oK8SNVU2EoFuX+a63en3dNJL7Jv90c+elNkawLOdtz9hk0BpsUI33PDPdIMi1+PW4oWJnTpzmxYHwO9KuTgjKOtneJrmyAyr+rFgQ==;U2FsdGVkX1+Z7IVZoNNI3PazrluxzKUdhRpRBFO7k8HTyWpW7Oe2zt8D2OJmcduk7szFmTnH2IbBMWZfDqSzxA=="
 
 steps:
-  - label: "{{matrix.queue}} tests - Julia {{matrix.version}}"
+  # Only the current release reports coverage. Julia 1.10 emits a coverage slot for the
+  # simulator method `@stable` generates, which is only ever inferred and never run, so the
+  # signature line of every stabilized function comes back uncovered. Julia 1.12 no longer
+  # emits that slot, and a zero from the 1.10 upload would outvote it.
+  - label: "{{matrix.queue}} tests - Julia 1"
     matrix:
       setup:
-        version:
-          - "1.10"
-          - "1"
         queue:
           - "cuda"
           - "metal"
     plugins:
       - JuliaCI/julia#v1:
-          version: "{{matrix.version}}"
+          version: "1"
       - JuliaCI/julia-test#v1: ~
       - JuliaCI/julia-coverage#v1:
           codecov: true
+    agents:
+      queue: "{{matrix.queue}}"
+    timeout_in_minutes: 60
+    if: build.message !~ /\[skip tests\]/
+    env:
+      COOLPDLP_TEST_GROUP: "{{matrix.queue}}"
+
+  - label: "{{matrix.queue}} tests - Julia 1.10"
+    matrix:
+      setup:
+        queue:
+          - "cuda"
+          - "metal"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+      - JuliaCI/julia-test#v1: ~
     agents:
       queue: "{{matrix.queue}}"
     timeout_in_minutes: 60

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -44,11 +44,17 @@ jobs:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
+      # Only the current release reports coverage. Julia 1.10 emits a coverage slot for the
+      # simulator method `@stable` generates, which is only ever inferred and never run, so
+      # the signature line of every stabilized function comes back uncovered. Julia 1.12 no
+      # longer emits that slot, and a zero from the 1.10 upload would outvote it.
       - uses: julia-actions/julia-runtest@v1
         with:
-          coverage: ${{ matrix.group != 'Perf' }}
+          coverage: ${{ matrix.group != 'Perf' && matrix.version == '1' }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.group != 'Perf' && matrix.version == '1'
       - uses: codecov/codecov-action@v7
+        if: matrix.group != 'Perf' && matrix.version == '1'
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
DispatchDoctor's `@stable` macro doesn't play well together with code coverage in Julia 1.10, causing lines to show up in the coverage report that can never be hit. Work around that by only reporting coverage for the latest Julia release.
